### PR TITLE
Updated yolo.py

### DIFF
--- a/yolo.py
+++ b/yolo.py
@@ -64,7 +64,7 @@ image = cv2.imread(args["image"])
 
 # determine only the *output* layer names that we need from YOLO
 ln = net.getLayerNames()
-ln = [ln[i[0] - 1] for i in net.getUnconnectedOutLayers()]
+ln = [ln[i - 1] for i in net.getUnconnectedOutLayers()]
 
 # construct a blob from the input image and then perform a forward
 # pass of the YOLO object detector, giving us our bounding boxes and


### PR DESCRIPTION
fixed IndexError: invalid index to scalar variable
changed this from -> ln = [ln[i[1] - 1] for i in net.getUnconnectedOutLayers()] to ln = [ln[i - 1] for i in net.getUnconnectedOutLayers()]